### PR TITLE
a

### DIFF
--- a/core/core.vcxproj
+++ b/core/core.vcxproj
@@ -66,6 +66,7 @@
       <ExceptionHandling>Async</ExceptionHandling>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>StdInclude.hpp</PrecompiledHeaderFile>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/core/src/GameInterface.hpp
+++ b/core/src/GameInterface.hpp
@@ -80,6 +80,7 @@ namespace IWXMVM
 			}
 		}
 
+		bool playBackPatch = false;
 
 		struct DemoInfo
 		{
@@ -93,7 +94,7 @@ namespace IWXMVM
 		virtual DemoInfo GetDemoInfo() = 0;
 
 
-		virtual void SetDemoPlaybackState(bool paused) = 0;
+		virtual void SetDemoPlaybackState() = 0;
 		virtual bool IsDemoPlaybackPaused() = 0;
 
 		virtual std::optional<Dvar> GetDvar(const std::string name) = 0;

--- a/core/src/Mod.cpp
+++ b/core/src/Mod.cpp
@@ -26,7 +26,7 @@ namespace IWXMVM
 			LOG_INFO("Game: {}", gameInterface->GetGameName());
 			LOG_INFO("Game Path: {}", PathUtils::GetCurrentExecutablePath());
 
-			MemoryUtils::UnprotectModule();
+			//MemoryUtils::UnprotectModule();
 
 			LOG_DEBUG("Installing game hooks...");
 			gameInterface->InstallHooks();

--- a/core/src/UI/Components/ControlBar.cpp
+++ b/core/src/UI/Components/ControlBar.cpp
@@ -64,7 +64,7 @@ namespace IWXMVM::UI
 		ImGui::SameLine(playbackSpeedSliderX - 10 - pauseButtonSize.x);
 		if (ImGui::ImageButton(image.GetTextureID(), pauseButtonSize, ImVec2(0, 0), ImVec2(1, 1), 1))
 		{
-			Mod::GetGameInterface()->SetDemoPlaybackState(!Mod::GetGameInterface()->IsDemoPlaybackPaused());
+			Mod::GetGameInterface()->SetDemoPlaybackState();
 		}
 
 		ImGui::End();

--- a/core/src/UI/UIManager.cpp
+++ b/core/src/UI/UIManager.cpp
@@ -36,7 +36,7 @@ namespace IWXMVM::UI::UIManager
 
 			//ImGui::ShowDemoWindow(&show_demo_window);
 
-
+			//ImGui::EndFrame();
 			ImGui::Render();
 			ImGui_ImplDX9_RenderDrawData(ImGui::GetDrawData());
 		}
@@ -53,25 +53,14 @@ namespace IWXMVM::UI::UIManager
 		}
 	}
 
-	typedef LRESULT(WINAPI * WndProc_t)(HWND, UINT, WPARAM, LPARAM);
-	WndProc_t GameWndProc = nullptr;
-	LRESULT WINAPI ImGuiWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
+	WNDPROC GameWndProc = nullptr;
+	HRESULT ImGuiWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 	{
-		if (ImGui_ImplWin32_WndProcHandler(hWnd, msg, wParam, lParam))
+		if (ImGui_ImplWin32_WndProcHandler(hWnd, uMsg, wParam, lParam)) {
 			return true;
-
-		ImGuiIO& io = ImGui::GetIO();
-		if (io.WantCaptureMouse || io.WantCaptureKeyboard)
-			return true;
-
-		switch (msg)
-		{
-		case WM_DESTROY:
-			PostQuitMessage(0);
-			return 0;
 		}
 
-		return GameWndProc(hWnd, msg, wParam, lParam);
+		return CallWindowProc(GameWndProc, hWnd, uMsg, wParam, lParam);
 	}
 
 	void SetImGuiStyle()
@@ -108,7 +97,7 @@ namespace IWXMVM::UI::UIManager
 
 			// TODO: byte size is game dependent
 			LOG_DEBUG("Hooking WndProc at {0:x}", Mod::GetGameInterface()->GetWndProc());
-			GameWndProc = HookManager::CreateHook<WndProc_t>(Mod::GetGameInterface()->GetWndProc(), ImGuiWndProc, 6);
+			GameWndProc = (WNDPROC)SetWindowLongPtr(hwnd, GWLP_WNDPROC, (LONG_PTR)ImGuiWndProc);
 
 			LOG_DEBUG("Initializing {0} UI components", uiComponents.size());
 

--- a/core/src/Utilities/HookManager.cpp
+++ b/core/src/Utilities/HookManager.cpp
@@ -3,20 +3,81 @@
 
 namespace IWXMVM::HookManager
 {
-	void WriteJump(std::uintptr_t from, const std::uintptr_t to, std::size_t len)
+	bool WriteJump(std::uintptr_t from, std::uintptr_t to, std::size_t size)
 	{
-		const auto jumpOffset = to - from - 5;
+		DWORD curProtection;
 
-		*(std::uint8_t*)from = 0xE9;
-		std::memcpy(reinterpret_cast<void*>(from + 1), &jumpOffset, sizeof(jumpOffset));
-
-		if (len > 5)
-		{
-			*(std::uint8_t*)from = 0xE9;
-			for (uint32_t i = 0; i < len - 5; i++)
-			{
-				*(uint8_t*)(from + 5 + i) = 0x90;
-			}
+		if (!VirtualProtect(reinterpret_cast<LPVOID>(from), size, PAGE_EXECUTE_READWRITE, &curProtection)) {
+			throw std::runtime_error("VirtualProtect failure. Address: " + std::to_string(from) + ", size: " + std::to_string(size));
+			return false;
 		}
+
+		std::uintptr_t relativeAddress = (to - from) - 5;
+		*reinterpret_cast<uint8_t*>(from) = 0xE9;
+		*reinterpret_cast<std::uintptr_t*>(from + 1) = relativeAddress;
+
+		if (*reinterpret_cast<uint8_t*>(from) != 0xE9 || *reinterpret_cast<std::uintptr_t*>(from + 1) != relativeAddress) {
+			throw std::runtime_error("Memory access failure. Addresses: " + std::to_string(from) + ", " + std::to_string(from + 1));
+			return false;
+		}
+
+		if (!VirtualProtect(reinterpret_cast<LPVOID>(from), size, curProtection, &curProtection)) {
+			throw std::runtime_error("VirtualProtect failure. Address: " + std::to_string(from) + ", size: " + std::to_string(size));
+			return false;
+		}
+
+		return true;
+	}
+
+	void* CreateHook(std::uintptr_t from, std::uintptr_t to, std::size_t size, bool stolenBytes)
+	{
+		if (size < 5) {
+			throw std::runtime_error("Size too small to place hook!");
+			return 0;
+		}
+
+		void* gateway = VirtualAlloc(0, size + 8, MEM_COMMIT | MEM_RESERVE, PAGE_EXECUTE_READWRITE);
+
+		if (!gateway) {
+			throw std::runtime_error("VirtualAlloc failure. Size: " + std::to_string(size));
+			return 0;
+		}
+
+		int offset1 = 0;
+		int offset2 = 5 - static_cast<int>(size);
+
+		if (stolenBytes) {
+			if (!memcpy(gateway, reinterpret_cast<std::uintptr_t*>(from), size)) {
+				throw std::runtime_error("Memcpy failure. Addresses: " + std::to_string(reinterpret_cast<std::uintptr_t>(gateway)) + ", " + std::to_string(from) + ", size: " + std::to_string(size));
+				return 0;
+			}
+
+			if (*reinterpret_cast<uint8_t*>(from) == 0xE8 || *reinterpret_cast<uint8_t*>(from) == 0xE9) {
+				void* gatewayTemp = static_cast<std::uintptr_t*>(gateway) + 1;
+				std::uintptr_t relativeAddress = *reinterpret_cast<std::uintptr_t*>(from + 1) + from + 5;
+				relativeAddress -= (reinterpret_cast<std::uintptr_t>(gatewayTemp) - 1 + 5);
+
+				*reinterpret_cast<std::uintptr_t*>(gatewayTemp) = relativeAddress;
+
+				if (*reinterpret_cast<std::uintptr_t*>(gatewayTemp) != relativeAddress) {
+					throw std::runtime_error("Memory access failure. Addresses: " + std::to_string(from) + ", " + std::to_string(from + 1));
+					return 0;
+				}
+			}
+
+			offset1 = size;
+			offset2 = 5;
+		}
+
+		std::uintptr_t gatewayRelativeAddress = (from - reinterpret_cast<std::uintptr_t>(gateway)) - offset2;
+		*reinterpret_cast<std::uint8_t*>(reinterpret_cast<std::uintptr_t>(gateway) + offset1) = 0xE9;
+		*reinterpret_cast<std::uintptr_t*>(reinterpret_cast<std::uintptr_t>(gateway) + offset1 + 1) = gatewayRelativeAddress;
+
+		if (*reinterpret_cast<std::uint8_t*>(reinterpret_cast<std::uintptr_t>(gateway) + offset1) != 0xE9 || *reinterpret_cast<std::uintptr_t*>(reinterpret_cast<std::uintptr_t>(gateway) + offset1 + 1) != gatewayRelativeAddress) {
+			throw std::runtime_error("Memory access failure. Addresses: " + std::to_string(reinterpret_cast<std::uintptr_t>(gateway) + offset1) + ", " + std::to_string(reinterpret_cast<std::uintptr_t>(gateway) + offset1 + 1));
+			return 0;
+		}
+
+		return (WriteJump(from, to, size) ? gateway : 0);
 	}
 }

--- a/core/src/Utilities/HookManager.hpp
+++ b/core/src/Utilities/HookManager.hpp
@@ -2,32 +2,8 @@
 
 namespace IWXMVM::HookManager
 {
-	void WriteJump(std::uintptr_t from, const std::uintptr_t to, std::size_t len = 5);
-
 	// TODO: Store placed hooks and unhook in Unhook function
 
-	template<typename FunctionSignature>
-	FunctionSignature CreateHook(uintptr_t functionAddress, FunctionSignature hook, uint8_t len)
-	{
-		const auto trampolineSize = len + 5;
-
-		auto trampolineAddress = reinterpret_cast<std::uintptr_t>(VirtualAlloc(
-			nullptr,
-			trampolineSize,
-			MEM_COMMIT | MEM_RESERVE,
-			PAGE_EXECUTE_READWRITE));
-
-		std::memcpy(reinterpret_cast<void*>(trampolineAddress), reinterpret_cast<const void*>(functionAddress), len);
-
-		trampolineAddress += len;
-
-		WriteJump(trampolineAddress, functionAddress + len);
-
-		DWORD oldProtection;
-		VirtualProtect(reinterpret_cast<void*>(trampolineAddress), trampolineSize, PAGE_EXECUTE_READ, &oldProtection);
-
-		WriteJump(functionAddress, (uintptr_t)hook, len);
-
-		return (FunctionSignature)(trampolineAddress - len);
-	}
+	bool WriteJump(std::uintptr_t from, std::uintptr_t to, std::size_t size);
+	void* CreateHook(std::uintptr_t from, std::uintptr_t to, std::size_t size, bool stolenBytes);
 };

--- a/iw3/iw3.vcxproj
+++ b/iw3/iw3.vcxproj
@@ -67,6 +67,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>StdInclude.hpp</PrecompiledHeaderFile>
       <PrecompiledHeaderOutputFile>$(IntDir)$(TargetName).pch</PrecompiledHeaderOutputFile>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/iw3/src/DemoParser.cpp
+++ b/iw3/src/DemoParser.cpp
@@ -38,12 +38,16 @@ namespace IWXMVM::IW3::DemoParser
 
 	void Run()
 	{
-		std::string path = Structures::GetFilePath(Mod::GetGameInterface()->GetDemoInfo().name + ".dm_1");
+		std::string str = static_cast<std::string>(Mod::GetGameInterface()->GetDemoInfo().name);
+		str += (str.ends_with(".dm_1")) ? "" : ".dm_1";
+
+		std::string path = Structures::GetFilePath(std::move(str));
 
 		std::ifstream file(path, std::ios::binary);
 		if (!file.is_open()) 
 		{
 			throw std::exception("failed to open demo file");
+			return;
 		}
 
 		std::vector<clientArchiveData_t> archives;

--- a/iw3/src/Hooks.cpp
+++ b/iw3/src/Hooks.cpp
@@ -3,40 +3,156 @@
 
 #include "Events.hpp"
 #include "Utilities/HookManager.hpp"
-
+#include "IW3Interface.hpp"
+#include "Mod.hpp"
 
 namespace IWXMVM::IW3::Hooks
 {
-
 	// TODO: Turn this into a "EventCallbacks" "patch"
 
-	typedef void(*RB_EndFrame_t)();
-	RB_EndFrame_t RB_EndFrame;
-	void __declspec(naked) RB_EndFrame_Hook()
-	{
-		__asm pushad
+	typedef HRESULT(_stdcall* EndScene_t)(IDirect3DDevice9* pDevice);
+	EndScene_t EndScene;
 
+	HRESULT _stdcall D3D_EndScene_Hook(IDirect3DDevice9* pDevice)
+	{
 		Events::Invoke(EventType::OnFrame);
-		
-		__asm popad
-		__asm jmp RB_EndFrame
+
+		return EndScene(pDevice);
+	}
+
+	typedef HRESULT(_stdcall* Reset_t)(IDirect3DDevice9* pDevice, D3DPRESENT_PARAMETERS* pPresentationParameters);
+	Reset_t	Reset;
+
+	HRESULT _stdcall D3D_Reset_Hook(IDirect3DDevice9* pDevice, D3DPRESENT_PARAMETERS* pPresentationParameters)
+	{
+		ImGui_ImplDX9_InvalidateDeviceObjects();
+		HRESULT hr = Reset(pDevice, pPresentationParameters);
+		ImGui_ImplDX9_CreateDeviceObjects();
+
+		return hr;
+	}
+
+	int realtime = 0;
+
+	// run every frame
+	void CL_CGameRendering_Internal()
+	{
+		if (IWXMVM::Mod::GetGameInterface()->playBackPatch) {
+			if (realtime == 0) {
+				realtime = *(int*)0x956E98; // cls->realtime
+			}
+			*(int*)0x956E98 = realtime;
+		} else {
+			realtime = 0;
+		}
+	}
+
+	typedef void(*CL_CGameRendering_t)();
+	CL_CGameRendering_t CL_CGameRendering;
+	void _declspec(naked) CL_CGameRendering_Hook()
+	{
+		_asm pushad
+
+		CL_CGameRendering_Internal();
+
+		_asm
+		{
+			popad
+			jmp CL_CGameRendering
+		}
+	}
+
+	void CL_PlayDemo_Internal(uintptr_t** address, char* cmd)
+	{
+		if (address != 0) {
+			reinterpret_cast<uintptr_t(*)()>(*address)();
+
+			if (!strcmp(cmd, "demo")) {
+				Events::Invoke(EventType::OnDemoLoad);
+			}
+		}
 	}
 
 	typedef void(*CL_PlayDemo_t)();
 	CL_PlayDemo_t CL_PlayDemo_f;
-	void __declspec(naked) CL_PlayDemo_Hook()
+	void _declspec(naked) CL_PlayDemo_Hook1()
 	{
-		__asm pushad
+		_asm
+		{
+			pushad
+			push ebp
+			mov ebp, esp
+			sub esp, 0x20
+		}
 
-		Events::Invoke(EventType::OnDemoLoad);
+		uintptr_t** address;
+		char* cmd;
 
-		__asm popad
-		__asm jmp CL_PlayDemo_f
+		_asm
+		{
+			lea esi, [esi + 0x10]
+			mov address, esi
+			mov cmd, ebx
+		}
+
+		CL_PlayDemo_Internal(address, cmd);
+
+		_asm
+		{
+			mov esp, ebp
+			pop ebp
+			popad
+			jmp CL_PlayDemo_f
+		}
 	}
 
-	void Install()
+	struct cmd_function_t
 	{
-		RB_EndFrame = HookManager::CreateHook<RB_EndFrame_t>(0x615460, RB_EndFrame_Hook, 6);
-		CL_PlayDemo_f = HookManager::CreateHook<CL_PlayDemo_t>(0x4692D9, CL_PlayDemo_Hook, 9);
+		cmd_function_t* next;
+		char* name;
+		char* autocomplete1;
+		char* autocomplete2;
+		void* function;
+	};
+
+	uintptr_t* ptrCL_PlayDemo_f = nullptr;
+	cmd_function_t** sv_cmd_functions = ((cmd_function_t**)(0x14099DC));
+
+	void Cmd_ModifyServerCommand(const char* cmd_name, void* function)
+	{
+		for (cmd_function_t* cmd = *sv_cmd_functions; cmd; cmd = cmd->next) {
+			if (!strcmp(cmd_name, cmd->name) && function != nullptr) {
+				if (function != nullptr) {
+					ptrCL_PlayDemo_f = (uintptr_t*)cmd->function;
+					cmd->function = function;
+
+					break;
+				}
+			}
+		}
+	}
+
+	void CL_PlayDemo_Hook2()
+	{
+		for (cmd_function_t* cmd = *sv_cmd_functions; cmd; cmd = cmd->next) {
+			if (!strcmp(cmd->name, "demo") && ptrCL_PlayDemo_f != nullptr) {
+				reinterpret_cast<uintptr_t(*)()>(ptrCL_PlayDemo_f)();
+
+				Events::Invoke(EventType::OnDemoLoad);
+				break;
+			}
+		}
+	}
+
+	void Install(IDirect3DDevice9* device)
+	{
+		void** vTable = *reinterpret_cast<void***>(device);
+
+		EndScene = (EndScene_t)HookManager::CreateHook((std::uintptr_t)vTable[42], (std::uintptr_t)&D3D_EndScene_Hook, 7, true);
+		Reset = (Reset_t)HookManager::CreateHook((std::uintptr_t)vTable[16], (std::uintptr_t)&D3D_Reset_Hook, 5, true);
+
+		Cmd_ModifyServerCommand("demo", CL_PlayDemo_Hook2);
+		//CL_PlayDemo_f = (CL_PlayDemo_t)HookManager::CreateHook(0x4F8F96, (std::uintptr_t)&CL_PlayDemo_Hook1, 9, false);
+		CL_CGameRendering = (CL_CGameRendering_t)HookManager::CreateHook(0x474DA0, (std::uintptr_t)&CL_CGameRendering_Hook, 7, true);
 	}
 }

--- a/iw3/src/Hooks.hpp
+++ b/iw3/src/Hooks.hpp
@@ -1,8 +1,10 @@
 #pragma once
 
+#include <d3d9.h>
+
 namespace IWXMVM::IW3::Hooks
 {
 	void CG_Draw2D_Hook();
 
-	void Install();
+	void Install(IDirect3DDevice9* device);
 }

--- a/iw3/src/IW3Interface.hpp
+++ b/iw3/src/IW3Interface.hpp
@@ -19,7 +19,7 @@ namespace IWXMVM::IW3
 
 		void InstallHooks() override
 		{
-			Hooks::Install();
+			Hooks::Install(GetD3D9Device());
 		}
 
 		void SetupEventListeners() override
@@ -64,20 +64,22 @@ namespace IWXMVM::IW3
 		{
 			DemoInfo demoInfo;
 			demoInfo.name = Structures::GetClientConnection()->demoName;
-			demoInfo.path = Structures::GetFilePath(demoInfo.name + ".dm_1");
+
+			std::string str = static_cast<std::string>(demoInfo.name);
+			str += (str.ends_with(".dm_1")) ? "" : ".dm_1";
+			demoInfo.path = Structures::GetFilePath(std::move(str));
+
 			demoInfo.currentTick = Structures::GetClientActive()->serverTime - DemoParser::demoStartTick;
 			demoInfo.endTick = DemoParser::demoEndTick - DemoParser::demoStartTick;
 
 			return demoInfo;
 		}
 
+		bool pausePlayBack = false;
 
-		void SetDemoPlaybackState(bool paused) override
+		void SetDemoPlaybackState() override
 		{
-			if (paused)
-				DemoPlaybackPatch::Install();
-			else
-				DemoPlaybackPatch::Uninstall();
+			playBackPatch = !playBackPatch;
 		}
 
 		bool IsDemoPlaybackPaused() override

--- a/iw3/src/Patches/DemoPlaybackPatch.cpp
+++ b/iw3/src/Patches/DemoPlaybackPatch.cpp
@@ -8,25 +8,34 @@ namespace IWXMVM::IW3
 
 	uint8_t originalCode[32];
 
-
 	void DemoPlaybackPatch::Install()
 	{
 		if (IsInstalled())
 			return;
+
+		DWORD curProtection;
+		VirtualProtect(reinterpret_cast<LPVOID>(PATCH_ADDRESS), PATCH_SIZE, PAGE_EXECUTE_READWRITE, &curProtection);
 
 		for (size_t i = 0; i < PATCH_SIZE; i++)
 		{
 			originalCode[i] = *(uint8_t*)(PATCH_ADDRESS + i);
 			*(uint8_t*)(PATCH_ADDRESS + i) = 0x90;
 		}
+
+		VirtualProtect(reinterpret_cast<LPVOID>(PATCH_ADDRESS), PATCH_SIZE, curProtection, &curProtection);
 	}
 
 	void DemoPlaybackPatch::Uninstall()
 	{
+		DWORD curProtection;
+		VirtualProtect(reinterpret_cast<LPVOID>(PATCH_ADDRESS), PATCH_SIZE, PAGE_EXECUTE_READWRITE, &curProtection);
+
 		for (size_t i = 0; i < PATCH_SIZE; i++)
 		{
 			*(uint8_t*)(PATCH_ADDRESS + i) = originalCode[i];
 		}
+
+		VirtualProtect(reinterpret_cast<LPVOID>(PATCH_ADDRESS), PATCH_SIZE, curProtection, &curProtection);
 	}
 
 	bool DemoPlaybackPatch::IsInstalled()


### PR DESCRIPTION
- major rewrite of the hooking function
- d3d reset is hooked - fixes full screen alt tabbing
- d3d endscene is hooked instead of the game's endscene
- different method of 'hooking' target window - fixes imgui interactivity bug on cod4x
- moved the CL_PlayDemo hook, added alternative method via cmd structs
- removed demo playback pause patch - added a hook that runs every frame and executes the equivalent of the patch when activated