### PR TITLE
GameView fixed aspect ratio

### DIFF
--- a/core/src/UI/Components/GameView.cpp
+++ b/core/src/UI/Components/GameView.cpp
@@ -51,9 +51,9 @@ namespace IWXMVM::UI
 		return true;
 	}
 
-	ImVec2 WindowResizing(ImVec2 window)
+	ImVec2 WindowResizing(ImVec2 window, float frame_height)
 	{
-		float aspect_ratio = 16.0f / 9.0f; // Clamp to 16:9, should use whatever struct from cod4 for other resolutions
+		float aspect_ratio = 16.0f / 9.0f; // Clamp to 16:9, should use whatever struct from cod4 dynamic scales
 
 		if (window.x / window.y > aspect_ratio) {
 			// If too wide, adjust width
@@ -64,7 +64,7 @@ namespace IWXMVM::UI
 			window.y = window.x / aspect_ratio;
 		}
 
-		return window;
+		return ImVec2(window.x, window.y - frame_height);
 	}
 
     void GameView::Initialize()
@@ -79,14 +79,14 @@ namespace IWXMVM::UI
 
 	void GameView::Render()
 	{
+
 		ImGui::Begin("GameView", NULL, ImGuiWindowFlags_NoScrollbar);
 		auto viewportSize = ImGui::GetContentRegionMax();
 
-		
 		if (textureSize.x != viewportSize.x || textureSize.y != viewportSize.y)
 		{
-			textureSize = WindowResizing(viewportSize);
-			CreateTexture(texture, WindowResizing(viewportSize));
+			textureSize = viewportSize;
+			CreateTexture(texture, viewportSize);
 		}
 
 		if (!CaptureBackBuffer(texture))
@@ -94,7 +94,7 @@ namespace IWXMVM::UI
 			throw std::exception("Failed to capture game view");
 		}
 
-		ImGui::Image((void*)texture, WindowResizing(viewportSize));
+		ImGui::Image((void*)texture, WindowResizing(viewportSize, ImGui::GetFrameHeight()));
 
 		ImGui::ShowDemoWindow();
 

--- a/core/src/UI/Components/GameView.cpp
+++ b/core/src/UI/Components/GameView.cpp
@@ -51,6 +51,22 @@ namespace IWXMVM::UI
 		return true;
 	}
 
+	ImVec2 WindowResizing(ImVec2 window)
+	{
+		float aspect_ratio = 16.0f / 9.0f; // Clamp to 16:9, should use whatever struct from cod4 for other resolutions
+
+		if (window.x / window.y > aspect_ratio) {
+			// If too wide, adjust width
+			window.x = window.y * aspect_ratio;
+		}
+		else if (window.x / window.y < aspect_ratio) {
+			// If too tall, adjust height
+			window.y = window.x / aspect_ratio;
+		}
+
+		return window;
+	}
+
     void GameView::Initialize()
     {
 		// since this is executed inside the constructor, it's too early to use the interface pointer!
@@ -61,29 +77,29 @@ namespace IWXMVM::UI
 		}*/
     }
 
-    void GameView::Render()
-    {
+	void GameView::Render()
+	{
 		ImGui::Begin("GameView", NULL, ImGuiWindowFlags_NoScrollbar);
+		auto viewportSize = ImGui::GetContentRegionMax();
 
-		const auto viewportSize = ImGui::GetContentRegionMax();
-
-		if (textureSize.x != viewportSize.x || textureSize.y != viewportSize.y) 
+		
+		if (textureSize.x != viewportSize.x || textureSize.y != viewportSize.y)
 		{
-			textureSize = viewportSize;
-			CreateTexture(texture, viewportSize);
+			textureSize = WindowResizing(viewportSize);
+			CreateTexture(texture, WindowResizing(viewportSize));
 		}
 
-		if (!CaptureBackBuffer(texture)) 
+		if (!CaptureBackBuffer(texture))
 		{
 			throw std::exception("Failed to capture game view");
 		}
 
-		ImGui::Image((void*)texture, viewportSize);
+		ImGui::Image((void*)texture, WindowResizing(viewportSize));
 
 		ImGui::ShowDemoWindow();
 
 		ImGui::End();
-    }
+	}
 
 	void GameView::Release()
 	{


### PR DESCRIPTION
Hardcoded to stay at 16:9 resolution, should use whatever struct to dynamically change that in the future.
Also the ImGui window does not have any scaling applied, so maybe need to add ImGui::SetNextWindowSize next?