### PR TITLE
Fix ejection/reinjection

### DIFF
--- a/core/src/Mod.cpp
+++ b/core/src/Mod.cpp
@@ -13,6 +13,16 @@ namespace IWXMVM
 {
 	GameInterface* Mod::internalGameInterface = nullptr;
 
+	HMODULE GetCurrentModule()
+	{
+		static bool dummy;
+
+		MEMORY_BASIC_INFORMATION mbi;
+		::VirtualQuery(&dummy, &mbi, sizeof(mbi));
+
+		return static_cast<HMODULE>(mbi.AllocationBase);
+	}
+
 	void Mod::Initialize(GameInterface* gameInterface)
 	{
 		try 
@@ -41,13 +51,14 @@ namespace IWXMVM
 			while (!UI::UIManager::ejectRequested.load())
 				std::this_thread::sleep_for(std::chrono::milliseconds(1));
 
-			UI::UIManager::ShutdownImGui();
-			LOG_DEBUG("ImGui successfully shutdown");
 			HookManager::Unhook();
 			LOG_DEBUG("Unhooked");
+			UI::UIManager::ShutdownImGui();
+			LOG_DEBUG("ImGui successfully shutdown");
 			SetWindowLongPtr(Mod::GetGameInterface()->GetWindowHandle(), GWLP_WNDPROC, (LONG_PTR)UI::UIManager::GameWndProc);
 
 			WindowsConsole::Close();
+			::FreeLibraryAndExitThread(GetCurrentModule(), 0);
 		}
 		catch (std::exception& ex)
 		{

--- a/iw3/src/Entrypoint.cpp
+++ b/iw3/src/Entrypoint.cpp
@@ -12,8 +12,7 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
 {
     if (fdwReason == DLL_PROCESS_ATTACH) 
     {
-        std::thread t1{ []() { Mod::Initialize(&gameInterface); } };
-        t1.detach();
+        ::CreateThread(nullptr, 0, reinterpret_cast<LPTHREAD_START_ROUTINE>(Mod::Initialize), &gameInterface, 0, nullptr);
     }
     return TRUE;
 }


### PR DESCRIPTION
use winapi thread instead of stl thread in dllmain and reorder the functions that get called on ejection