### PR TITLE
Progress bar bug fix when no demo tick data is available

### DIFF
--- a/core/src/UI/Components/ControlBar.cpp
+++ b/core/src/UI/Components/ControlBar.cpp
@@ -45,8 +45,10 @@ namespace IWXMVM::UI
 		ImGui::Text("%s", Mod::GetGameInterface()->GetDemoInfo().name.c_str());
 
 		auto demoInfo = Mod::GetGameInterface()->GetDemoInfo();
-		ImGui::SameLine(panelSize.x / 4);
-		ImGui::DemoProgressBar(&demoInfo.currentTick, demoInfo.endTick, ImVec2(panelSize.x / 2, panelSize.y / 3.4f), std::format("{0}", demoInfo.currentTick).c_str());
+		if (demoInfo.endTick > 0) {
+			ImGui::SameLine(panelSize.x / 4);
+			ImGui::DemoProgressBar(&demoInfo.currentTick, demoInfo.endTick, ImVec2(panelSize.x / 2, panelSize.y / 3.4f), std::format("{0}", demoInfo.currentTick).c_str());
+		}
 
 		// Right side 
 

--- a/iw3/src/DemoParser.cpp
+++ b/iw3/src/DemoParser.cpp
@@ -93,6 +93,9 @@ namespace IWXMVM::IW3::DemoParser
 		}
 		else
 		{
+			demoStartTick = 0;
+			demoEndTick = 0;
+			
 			LOG_ERROR("Could not determine demo length due to lack of 256 client archives (found {0})", archives.size());
 		}
 	}


### PR DESCRIPTION
Performance drops when no demo tick data is available but the progress bar is still shown.