### PR TITLE
Small changes to free and orbit camera modes.

### DIFF
--- a/core/src/Components/CameraManager.cpp
+++ b/core/src/Components/CameraManager.cpp
@@ -50,8 +50,6 @@ namespace IWXMVM::Components
 		// TODO: make this configurable
 		constexpr float FREECAM_SPEED = 300;
 		constexpr float MOUSE_SPEED = 0.1f;
-		constexpr float HEIGHT_CEILING = 250.0f;
-		constexpr float HEIGHT_MULTIPLIER = 0.75f;
 		constexpr float SCROLL_LOWER_BOUNDARY = -0.001f;
 		constexpr float SCROLL_UPPER_BOUNDARY = 0.001f;
 		const float SMOOTHING_FACTOR = glm::clamp(1.0f - 15.0f * Input::GetDeltaTime(), 0.0f, 1.0f);
@@ -61,8 +59,9 @@ namespace IWXMVM::Components
 		auto speedModifier = Input::KeyHeld(ImGuiKey_LeftShift) ? 0.1f : 1.0f;
 		speedModifier *= Input::KeyHeld(ImGuiKey_LeftCtrl) ? 3.0f : 1.0f;
 
-		const auto cameraHeightSpeed = Input::GetDeltaTime() * FREECAM_SPEED;
-		const auto cameraMovementSpeed = speedModifier * cameraHeightSpeed + Input::GetDeltaTime() * HEIGHT_MULTIPLIER * (std::abs(cameraPosition[2]) / HEIGHT_CEILING);
+		const auto cameraBaseSpeed = Input::GetDeltaTime() * FREECAM_SPEED;
+		const auto cameraMovementSpeed = cameraBaseSpeed * speedModifier;
+		const auto cameraHeightSpeed = cameraMovementSpeed;
 
 		if (Input::KeyHeld(ImGuiKey_W))
 		{
@@ -103,6 +102,12 @@ namespace IWXMVM::Components
 				scrollDelta = 0.0;
 			}
 		}
+
+		if (Input::MouseButtonHeld(ImGuiMouseButton_Middle)) 
+		{
+			activeCamera.GetRotation() = {};
+			activeCamera.GetFov() = 90.0f;
+		}
 	
 		activeCamera.GetRotation()[0] += Input::GetMouseDelta()[1] * MOUSE_SPEED;
 		activeCamera.GetRotation()[1] -= Input::GetMouseDelta()[0] * MOUSE_SPEED;
@@ -122,7 +127,7 @@ namespace IWXMVM::Components
 		auto& cameraPosition = activeCamera.GetPosition();
 	
 		constexpr float BASE_SPEED = 0.1f;
-		constexpr float ROTATION_SPEED = BASE_SPEED * 2.0f;
+		constexpr float ROTATION_SPEED = BASE_SPEED * 1.5f;
 		constexpr float TRANSLATION_SPEED = BASE_SPEED * 3.0f;
 		constexpr float ZOOM_SPEED = BASE_SPEED * 8.0f;
 		constexpr float HEIGHT_CEILING = 250.0f;


### PR DESCRIPTION
1. Removed height factor for free camera as it didn't do anything and has been replaced by left shift / left ctrl multipliers.
2. These multipliers now also affect going up and down (Q/E).
3. Clicking scroll button now resets the camera for free camera.
4. Slightly reduced the rotation speed for the orbit camera.