### PR TITLE
D3D9 Hooking rework

### DIFF
--- a/core/src/D3D9.cpp
+++ b/core/src/D3D9.cpp
@@ -58,16 +58,12 @@ namespace IWXMVM::D3D9
 
 	HRESULT __stdcall CreateDevice_Hook(IDirect3D9* pInterface, UINT Adapter, D3DDEVTYPE DeviceType, HWND hFocusWindow, DWORD BehaviorFlags, D3DPRESENT_PARAMETERS* pPresentationParameters, IDirect3DDevice9** ppReturnedDeviceInterface)
 	{
-		LOG_DEBUG("CreateDevice called");
+		LOG_DEBUG("CreateDevice called with hwnd {}", pPresentationParameters->hDeviceWindow);
 
 		UI::UIManager::Get().ShutdownImGui();
 
-		LOG_DEBUG("hFocusWindow: {}; other: {}", (std::uintptr_t)hFocusWindow, (std::uintptr_t)pPresentationParameters->hDeviceWindow);
-
 		HRESULT hr = CreateDevice(pInterface, Adapter, DeviceType, hFocusWindow, BehaviorFlags, pPresentationParameters, ppReturnedDeviceInterface);
 		device = *ppReturnedDeviceInterface;
-
-		LOG_DEBUG("hFocusWindow: {}; other: {}", (std::uintptr_t)hFocusWindow, (std::uintptr_t)pPresentationParameters->hDeviceWindow);
 
 		UI::UIManager::Get().Initialize(device, pPresentationParameters->hDeviceWindow);
 

--- a/core/src/D3D9.cpp
+++ b/core/src/D3D9.cpp
@@ -58,7 +58,7 @@ namespace IWXMVM::D3D9
 
 	HRESULT __stdcall CreateDevice_Hook(IDirect3D9* pInterface, UINT Adapter, D3DDEVTYPE DeviceType, HWND hFocusWindow, DWORD BehaviorFlags, D3DPRESENT_PARAMETERS* pPresentationParameters, IDirect3DDevice9** ppReturnedDeviceInterface)
 	{
-		LOG_DEBUG("CreateDevice called with hwnd {}", pPresentationParameters->hDeviceWindow);
+		LOG_DEBUG("CreateDevice called with hwnd {}", (std::uintptr_t)pPresentationParameters->hDeviceWindow);
 
 		UI::UIManager::Get().ShutdownImGui();
 

--- a/core/src/UI/UIManager.hpp
+++ b/core/src/UI/UIManager.hpp
@@ -46,19 +46,13 @@ namespace IWXMVM::UI
 		UIManager(UIManager const&) = delete;
 		void operator=(UIManager const&) = delete;
 
-		void Initialize(IDirect3DDevice9* device);
+		void Initialize(IDirect3DDevice9* device, HWND hwnd = nullptr);
 		void ShutdownImGui();
-		bool RestartImGui();
 		void RunImGuiFrame();
 
 		bool IsInitialized() const
 		{
 			return isInitialized;
-		}
-
-		std::atomic<bool> const& NeedsRestart() const
-		{
-			return needsRestart;
 		}
 
 		WNDPROC GetOriginalGameWndProc() const
@@ -122,8 +116,6 @@ namespace IWXMVM::UI
 		bool hideOverlay = false;
 		bool showImGuiDemo = false;
 		bool showDebugPanel = false;
-
-		std::atomic<bool> needsRestart = false;
 
 		WNDPROC originalGameWndProc = nullptr;
 	};

--- a/iw3/src/Hooks/Commands.cpp
+++ b/iw3/src/Hooks/Commands.cpp
@@ -195,18 +195,7 @@ namespace IWXMVM::IW3::Hooks::Commands
 		//Events::Invoke(EventType::OnDemoLoad); 
 	}
 
-	void CL_Vid_Restart_Hook()
-	{
-		auto* oldFunction = FindOriginalFunction(CL_Vid_Restart_Hook);
-		if (oldFunction == nullptr)
-			return;
-
-		if (UI::UIManager::Get().RestartImGui())
-			reinterpret_cast<void(*)()>(oldFunction)();
-	}
-
 	std::vector<FunctionStorage> CmdHooks{
-		{ "vid_restart",	FunctionStorage::CommandType::ServerCommand,	CL_Vid_Restart_Hook },
 		{ "demo",		FunctionStorage::CommandType::ServerCommand,	CL_PlayDemo_Hook },
 		{ "replayDemo",		FunctionStorage::CommandType::Command,		CL_ReplayDemo_Hook }
 	};


### PR DESCRIPTION
hook CreateDevice instead of relying on EndScene to provide device pointer