### PR TITLE
Fix Imgui memory free bug.

### DIFF
--- a/core/src/UI/UIManager.cpp
+++ b/core/src/UI/UIManager.cpp
@@ -220,6 +220,7 @@ namespace IWXMVM::UI
 			auto RegisterFont = [&](const char* name, const uint8_t* data, size_t size, float fontSize) 
 			{
 				ImFontConfig fontConfig;
+				fontConfig.FontDataOwnedByAtlas = false;
 				fontConfig.SizePixels = fontSize;
 				strcpy_s(fontConfig.Name, name);
 				io.Fonts->AddFontFromMemoryTTF((void*)data, size, fontSize, &fontConfig);
@@ -228,6 +229,7 @@ namespace IWXMVM::UI
 				auto iconFontSize = fontSize * 2.0f / 3.0f;
 				static const ImWchar icons_ranges[] = { ICON_MIN_FA, ICON_MAX_16_FA, 0 };
 				ImFontConfig icons_config;
+				icons_config.FontDataOwnedByAtlas = false;
 				icons_config.MergeMode = true;
 				icons_config.PixelSnapH = true;
 				icons_config.GlyphMinAdvanceX = iconFontSize;


### PR DESCRIPTION
Without these flags, Imgui will attempt to free these resources even though it hasn't taken ownership.