### PR TITLE
Fix CaptureMenu framerate combo box bug

### DIFF
--- a/core/src/UI/Components/CaptureMenu.cpp
+++ b/core/src/UI/Components/CaptureMenu.cpp
@@ -59,7 +59,7 @@ namespace IWXMVM::UI
 			const char* framerateComboItems[] = { "250", "500", "1000" };
 			static int currentFramerateComboItem = 0;
 			ImGui::SetNextItemWidth(200);
-			ImGui::Combo("##captureMenuResolutionCombo", &currentFramerateComboItem, framerateComboItems, IM_ARRAYSIZE(framerateComboItems));
+			ImGui::Combo("##captureMenuFramerateCombo", &currentFramerateComboItem, framerateComboItems, IM_ARRAYSIZE(framerateComboItems));
 
 			ImGui::End();
 		}


### PR DESCRIPTION
Previously the framerate combo would show on the resolution combo.