### PR TITLE
Moved the place where pre demo load events are executed

### DIFF
--- a/iw3/src/Hooks/Commands.cpp
+++ b/iw3/src/Hooks/Commands.cpp
@@ -177,8 +177,6 @@ namespace IWXMVM::IW3::Hooks::Commands
         if (oldFunction == nullptr)
             return;
 
-        Events::Invoke(EventType::PreDemoLoad);
-
         reinterpret_cast<void (*)()>(oldFunction)();
 
         Events::Invoke(EventType::PostDemoLoad);

--- a/iw3/src/IW3Interface.hpp
+++ b/iw3/src/IW3Interface.hpp
@@ -100,6 +100,8 @@ namespace IWXMVM::IW3
 
         void PlayDemo(std::filesystem::path demoPath) final
         {
+            Events::Invoke(EventType::PreDemoLoad);
+            
             const auto demoDirectory =
                 std::filesystem::path(GetDvar("fs_basepath")->value->string) / "players" / "demos";
 


### PR DESCRIPTION
To avoid ending up with an unclosed file handle, which happens when trying to replay the same demo.