### PR TITLE
Implemented Custom Timeframe Checkbox

### DIFF
--- a/core/src/Components/CaptureManager.cpp
+++ b/core/src/Components/CaptureManager.cpp
@@ -49,6 +49,13 @@ namespace IWXMVM::Components
         }
     }
 
+    void CaptureManager::SetTimeFrameToDefault()
+    {
+        auto endTick = Mod::GetGameInterface()->GetDemoInfo().endTick;
+        captureSettings.startTick = static_cast<int32_t>(endTick * 0.1);
+        captureSettings.endTick = static_cast<int32_t>(endTick * 0.9);
+    }
+
     void CaptureManager::Initialize()
     {
         IDirect3DDevice9* device = D3D9::GetDevice();
@@ -99,9 +106,7 @@ namespace IWXMVM::Components
         Events::RegisterListener(EventType::OnDemoBoundsDetermined, [&]() {
             if (captureSettings.startTick == 0 || captureSettings.endTick == 0)
             {
-                auto endTick = Mod::GetGameInterface()->GetDemoInfo().endTick;
-                captureSettings.startTick = static_cast<int32_t>(endTick * 0.1);
-                captureSettings.endTick = static_cast<int32_t>(endTick * 0.9);
+                SetTimeFrameToDefault();
             }
         });
 

--- a/core/src/Components/CaptureManager.cpp
+++ b/core/src/Components/CaptureManager.cpp
@@ -49,13 +49,6 @@ namespace IWXMVM::Components
         }
     }
 
-    void CaptureManager::SetTimeFrameToDefault()
-    {
-        auto endTick = Mod::GetGameInterface()->GetDemoInfo().endTick;
-        captureSettings.startTick = static_cast<int32_t>(endTick * 0.1);
-        captureSettings.endTick = static_cast<int32_t>(endTick * 0.9);
-    }
-
     void CaptureManager::Initialize()
     {
         IDirect3DDevice9* device = D3D9::GetDevice();
@@ -106,7 +99,9 @@ namespace IWXMVM::Components
         Events::RegisterListener(EventType::OnDemoBoundsDetermined, [&]() {
             if (captureSettings.startTick == 0 || captureSettings.endTick == 0)
             {
-                SetTimeFrameToDefault();
+                auto endTick = Mod::GetGameInterface()->GetDemoInfo().endTick;
+                captureSettings.startTick = static_cast<int32_t>(endTick * 0.1);
+                captureSettings.endTick = static_cast<int32_t>(endTick * 0.9);
             }
         });
 

--- a/core/src/Components/CaptureManager.hpp
+++ b/core/src/Components/CaptureManager.hpp
@@ -69,8 +69,6 @@ namespace IWXMVM::Components
 
         std::string_view GetOutputFormatLabel(OutputFormat outputFormat);
         std::string_view GetVideoCodecLabel(VideoCodec codec);
-
-        void SetTimeFrameToDefault();
         
         CaptureSettings& GetCaptureSettings()
         {

--- a/core/src/Components/CaptureManager.hpp
+++ b/core/src/Components/CaptureManager.hpp
@@ -47,6 +47,7 @@ namespace IWXMVM::Components
 
         Resolution resolution;
         int32_t framerate;
+        bool usingCustomTimeFrame;
     };
 
     class CaptureManager

--- a/core/src/Components/CaptureManager.hpp
+++ b/core/src/Components/CaptureManager.hpp
@@ -69,6 +69,8 @@ namespace IWXMVM::Components
 
         std::string_view GetOutputFormatLabel(OutputFormat outputFormat);
         std::string_view GetVideoCodecLabel(VideoCodec codec);
+
+        void SetTimeFrameToDefault();
         
         CaptureSettings& GetCaptureSettings()
         {

--- a/core/src/Components/KeyframeManager.cpp
+++ b/core/src/Components/KeyframeManager.cpp
@@ -259,27 +259,26 @@ namespace IWXMVM::Components
         }
 
         assert(p0Idx != -1 || p1Idx != -1);
+        assert(keyframes[p0Idx].tick < keyframes[p1Idx].tick);
         assert(p0Idx != p1Idx);
-        if (!(keyframes[p0Idx].tick < keyframes[p1Idx].tick))
-        {
-            const auto& p0 = keyframes[p0Idx];
-            const auto& p1 = keyframes[p1Idx];
 
-            const float t = static_cast<float>(tick - p0.tick) / static_cast<float>(p1.tick - p0.tick);
-            switch (valueType)
-            {
-                case Types::KeyframeValueType::FloatingPoint:
-                    return Types::KeyframeValue((1.0f - t) * p0.value.floatingPoint + t * p1.value.floatingPoint);
-                case Types::KeyframeValueType::Vector3:
-                    return Types::KeyframeValue((1.0f - t) * p0.value.vector3 + t * p1.value.vector3);
-                case Types::KeyframeValueType::CameraData:
-                    return Types::KeyframeValue(
-                        Types::CameraData((1.0f - t) * p0.value.cameraData.position + t * p1.value.cameraData.position,
-                                          (1.0f - t) * p0.value.cameraData.rotation + t * p1.value.cameraData.rotation,
-                                          (1.0f - t) * p0.value.cameraData.fov + t * p1.value.cameraData.fov));
-                default:
-                    return Types::KeyframeValue(0.0f);
-            }
+        const auto& p0 = keyframes[p0Idx];
+        const auto& p1 = keyframes[p1Idx];
+
+        const float t = static_cast<float>(tick - p0.tick) / static_cast<float>(p1.tick - p0.tick);
+        switch (valueType)
+        {
+            case Types::KeyframeValueType::FloatingPoint:
+                return Types::KeyframeValue((1.0f - t) * p0.value.floatingPoint + t * p1.value.floatingPoint);
+            case Types::KeyframeValueType::Vector3:
+                return Types::KeyframeValue((1.0f - t) * p0.value.vector3 + t * p1.value.vector3);
+            case Types::KeyframeValueType::CameraData:
+                return Types::KeyframeValue(
+                    Types::CameraData((1.0f - t) * p0.value.cameraData.position + t * p1.value.cameraData.position,
+                                      (1.0f - t) * p0.value.cameraData.rotation + t * p1.value.cameraData.rotation,
+                                      (1.0f - t) * p0.value.cameraData.fov + t * p1.value.cameraData.fov));
+            default:
+                return Types::KeyframeValue(0.0f);
         }
     }
 

--- a/core/src/Components/KeyframeManager.cpp
+++ b/core/src/Components/KeyframeManager.cpp
@@ -259,26 +259,27 @@ namespace IWXMVM::Components
         }
 
         assert(p0Idx != -1 || p1Idx != -1);
-        assert(keyframes[p0Idx].tick < keyframes[p1Idx].tick);
         assert(p0Idx != p1Idx);
-
-        const auto& p0 = keyframes[p0Idx];
-        const auto& p1 = keyframes[p1Idx];
-
-        const float t = static_cast<float>(tick - p0.tick) / static_cast<float>(p1.tick - p0.tick);
-        switch (valueType)
+        if (!(keyframes[p0Idx].tick < keyframes[p1Idx].tick))
         {
-            case Types::KeyframeValueType::FloatingPoint:
-                return Types::KeyframeValue((1.0f - t) * p0.value.floatingPoint + t * p1.value.floatingPoint);
-            case Types::KeyframeValueType::Vector3:
-                return Types::KeyframeValue((1.0f - t) * p0.value.vector3 + t * p1.value.vector3);
-            case Types::KeyframeValueType::CameraData:
-                return Types::KeyframeValue(
-                    Types::CameraData((1.0f - t) * p0.value.cameraData.position + t * p1.value.cameraData.position,
-                                      (1.0f - t) * p0.value.cameraData.rotation + t * p1.value.cameraData.rotation,
-                                      (1.0f - t) * p0.value.cameraData.fov + t * p1.value.cameraData.fov));
-            default:
-                return Types::KeyframeValue(0.0f);
+            const auto& p0 = keyframes[p0Idx];
+            const auto& p1 = keyframes[p1Idx];
+
+            const float t = static_cast<float>(tick - p0.tick) / static_cast<float>(p1.tick - p0.tick);
+            switch (valueType)
+            {
+                case Types::KeyframeValueType::FloatingPoint:
+                    return Types::KeyframeValue((1.0f - t) * p0.value.floatingPoint + t * p1.value.floatingPoint);
+                case Types::KeyframeValueType::Vector3:
+                    return Types::KeyframeValue((1.0f - t) * p0.value.vector3 + t * p1.value.vector3);
+                case Types::KeyframeValueType::CameraData:
+                    return Types::KeyframeValue(
+                        Types::CameraData((1.0f - t) * p0.value.cameraData.position + t * p1.value.cameraData.position,
+                                          (1.0f - t) * p0.value.cameraData.rotation + t * p1.value.cameraData.rotation,
+                                          (1.0f - t) * p0.value.cameraData.fov + t * p1.value.cameraData.fov));
+                default:
+                    return Types::KeyframeValue(0.0f);
+            }
         }
     }
 

--- a/core/src/UI/Components/CaptureMenu.cpp
+++ b/core/src/UI/Components/CaptureMenu.cpp
@@ -89,7 +89,7 @@ namespace IWXMVM::UI
                         }
                     }
 
-                    if (minTick != UINT32_MAX && maxTick)
+                    if (minTick != UINT32_MAX && maxTick && maxTick > minTick)
                     {
                         captureSettings.startTick = minTick;
                         captureSettings.endTick = maxTick;

--- a/core/src/UI/Components/CaptureMenu.cpp
+++ b/core/src/UI/Components/CaptureMenu.cpp
@@ -46,15 +46,58 @@ namespace IWXMVM::UI
             halfWidth -= ImGui::GetStyle().ItemSpacing.x / 2;
             auto endTick = Mod::GetGameInterface()->GetDemoInfo().endTick;
 
-            ImGui::AlignTextToFramePadding();
-            ImGui::Text("Timeframe");
-            ImGui::SameLine();
-            ImGui::SetCursorPosX(ImGui::GetWindowWidth() * fieldLayoutPercentage);
-            ImGui::SetNextItemWidth(halfWidth);
-            ImGui::DragInt("##startTickInput", (int32_t*)&captureSettings.startTick, 10, 0, captureSettings.endTick);
-            ImGui::SameLine();
-            ImGui::SetNextItemWidth(halfWidth);
-            ImGui::DragInt("##endTickInput", (int32_t*)&captureSettings.endTick, 10, captureSettings.startTick, endTick);
+            ImGui::Checkbox("Custom Timeframe", &captureSettings.usingCustomTimeFrame);
+
+            if (captureSettings.usingCustomTimeFrame)
+            {
+                ImGui::AlignTextToFramePadding();
+                ImGui::Text("Timeframe");
+                ImGui::SameLine();
+                ImGui::SetCursorPosX(ImGui::GetWindowWidth() * fieldLayoutPercentage);
+                ImGui::SetNextItemWidth(halfWidth);
+                ImGui::DragInt("##startTickInput", (int32_t*)&captureSettings.startTick, 10, 0,
+                               captureSettings.endTick);
+                ImGui::SameLine();
+                ImGui::SetNextItemWidth(halfWidth);
+                ImGui::DragInt("##endTickInput", (int32_t*)&captureSettings.endTick, 10, captureSettings.startTick,
+                               endTick);
+            }
+            else
+            {
+                // best place to put code? maybe only set timeframe on capture button click. 
+                // also maybe extract getting first and last keyframe to seperate function in KeyframeManager
+                std::map<Types::KeyframeableProperty, std::vector<Types::Keyframe>> keyframes =
+                    KeyframeManager::Get().GetKeyframes();
+
+                if (!keyframes.empty())
+                {
+                    std::uint32_t minTick = UINT32_MAX;
+                    std::uint32_t maxTick = 0;
+
+                    for (const auto& pair : keyframes)
+                    {
+                        for (const auto& keyframe : pair.second)
+                        {
+                            if (keyframe.tick < minTick)
+                            {
+                                minTick = keyframe.tick;
+                            }
+                            if (keyframe.tick > maxTick)
+                            {
+                                maxTick = keyframe.tick;
+                            }
+                        }
+                    }
+
+                    if (minTick != UINT32_MAX && maxTick)
+                    {
+                        captureSettings.startTick = minTick;
+                        captureSettings.endTick = maxTick;
+                    }
+                }
+                
+            }
+            
 
             ImGui::AlignTextToFramePadding();
             ImGui::Text("Output Format");

--- a/core/src/UI/Components/CaptureMenu.cpp
+++ b/core/src/UI/Components/CaptureMenu.cpp
@@ -64,7 +64,7 @@ namespace IWXMVM::UI
             }
             else
             {
-                // best place to put code? maybe only set timeframe on capture button click. 
+                // best place to put code? maybe only set timeframe on capture button click (though this is slightly less intuitive i would say). 
                 // also maybe extract getting first and last keyframe to seperate function in KeyframeManager
                 std::map<Types::KeyframeableProperty, std::vector<Types::Keyframe>> keyframes =
                     KeyframeManager::Get().GetKeyframes();

--- a/core/src/UI/Components/CaptureMenu.cpp
+++ b/core/src/UI/Components/CaptureMenu.cpp
@@ -94,6 +94,10 @@ namespace IWXMVM::UI
                         captureSettings.startTick = minTick;
                         captureSettings.endTick = maxTick;
                     }
+                    else
+                    {
+                        captureManager.SetTimeFrameToDefault();
+                    }
                 }
                 
             }

--- a/core/src/UI/Components/CaptureMenu.cpp
+++ b/core/src/UI/Components/CaptureMenu.cpp
@@ -94,10 +94,6 @@ namespace IWXMVM::UI
                         captureSettings.startTick = minTick;
                         captureSettings.endTick = maxTick;
                     }
-                    else
-                    {
-                        captureManager.SetTimeFrameToDefault();
-                    }
                 }
                 
             }

--- a/core/src/UI/Components/CaptureMenu.cpp
+++ b/core/src/UI/Components/CaptureMenu.cpp
@@ -48,24 +48,8 @@ namespace IWXMVM::UI
 
             ImGui::Checkbox("Custom Timeframe", &captureSettings.usingCustomTimeFrame);
 
-            if (captureSettings.usingCustomTimeFrame)
+            if (!captureSettings.usingCustomTimeFrame)
             {
-                ImGui::AlignTextToFramePadding();
-                ImGui::Text("Timeframe");
-                ImGui::SameLine();
-                ImGui::SetCursorPosX(ImGui::GetWindowWidth() * fieldLayoutPercentage);
-                ImGui::SetNextItemWidth(halfWidth);
-                ImGui::DragInt("##startTickInput", (int32_t*)&captureSettings.startTick, 10, 0,
-                               captureSettings.endTick);
-                ImGui::SameLine();
-                ImGui::SetNextItemWidth(halfWidth);
-                ImGui::DragInt("##endTickInput", (int32_t*)&captureSettings.endTick, 10, captureSettings.startTick,
-                               endTick);
-            }
-            else
-            {
-                // best place to put code? maybe only set timeframe on capture button click (though this is slightly less intuitive i would say). 
-                // also maybe extract getting first and last keyframe to seperate function in KeyframeManager
                 std::map<Types::KeyframeableProperty, std::vector<Types::Keyframe>> keyframes =
                     KeyframeManager::Get().GetKeyframes();
 
@@ -76,15 +60,17 @@ namespace IWXMVM::UI
 
                     for (const auto& pair : keyframes)
                     {
-                        for (const auto& keyframe : pair.second)
+                        if (!pair.second.empty())
                         {
-                            if (keyframe.tick < minTick)
+                            std::uint32_t front = pair.second.front().tick;
+                            std::uint32_t back = pair.second.back().tick;
+                            if (front < minTick)
                             {
-                                minTick = keyframe.tick;
+                                minTick = front;
                             }
-                            if (keyframe.tick > maxTick)
+                            if (back > maxTick)
                             {
-                                maxTick = keyframe.tick;
+                                maxTick = back;
                             }
                         }
                     }
@@ -99,8 +85,24 @@ namespace IWXMVM::UI
                         captureManager.SetTimeFrameToDefault();
                     }
                 }
+                ImGui::BeginDisabled();
                 
             }
+            ImGui::AlignTextToFramePadding();
+            ImGui::Text("Timeframe");
+            ImGui::SameLine();
+            ImGui::SetCursorPosX(ImGui::GetWindowWidth() * fieldLayoutPercentage);
+            ImGui::SetNextItemWidth(halfWidth);
+            ImGui::DragInt("##startTickInput", (int32_t*)&captureSettings.startTick, 10, 0, captureSettings.endTick);
+            ImGui::SameLine();
+            ImGui::SetNextItemWidth(halfWidth);
+            ImGui::DragInt("##endTickInput", (int32_t*)&captureSettings.endTick, 10, captureSettings.startTick,
+                           endTick);
+            if (!captureSettings.usingCustomTimeFrame)
+            {
+                ImGui::EndDisabled();
+            }
+            
             
 
             ImGui::AlignTextToFramePadding();


### PR DESCRIPTION
Created Custom Timeframe checkbox, when unchecked, in point will always be first keyframe and out point will always be last keyframe. 

The code that handles this i kept in the render function for capture tab, this has the side effect of the in and out point only being updated when recording tab is open, might want to look at moving the code somewhere else.

![image](https://github.com/reallyluckyy/IWXMVM/assets/48849543/19ae5942-c72a-4b59-ba3c-919e9d051f11)