### PR TITLE
General Workflow Improvments

### DIFF
--- a/core/src/Components/CameraManager.cpp
+++ b/core/src/Components/CameraManager.cpp
@@ -107,11 +107,11 @@ namespace IWXMVM::Components
                 if (i != activeCameraIndex)
                 {
                     previousActiveCameraIndex = activeCameraIndex;
+                    activeCameraIndex = i;
+                    Events::Invoke(EventType::OnCameraChanged);
+                    return;
                 }
-                activeCameraIndex = i;
             }
         }
-
-        Events::Invoke(EventType::OnCameraChanged);
     }
 }  // namespace IWXMVM::Components

--- a/core/src/Components/CameraManager.cpp
+++ b/core/src/Components/CameraManager.cpp
@@ -104,7 +104,10 @@ namespace IWXMVM::Components
         {
             if (cameras[i]->GetMode() == mode)
             {
-                previousActiveCameraIndex = activeCameraIndex;
+                if (i != activeCameraIndex)
+                {
+                    previousActiveCameraIndex = activeCameraIndex;
+                }
                 activeCameraIndex = i;
             }
         }

--- a/core/src/Components/CampathManager.cpp
+++ b/core/src/Components/CampathManager.cpp
@@ -5,6 +5,7 @@
 #include "UI/UIManager.hpp"
 #include "../Events.hpp"
 #include "../Input.hpp"
+#include "Playback.hpp"
 
 namespace IWXMVM::Components
 {
@@ -60,6 +61,20 @@ namespace IWXMVM::Components
             if (Input::BindDown(Action::DollyPlayPath))
             {
                 CameraManager::Get().SetActiveCamera(Camera::Mode::Dolly);
+                Playback::SetTickDelta(KeyframeManager::Get().GetKeyframes(property).front().tick -
+                                       Mod::GetGameInterface()->GetDemoInfo().currentTick, true);
+            }
+        }
+        else
+        {
+            if (Input::BindDown(Action::DollyPlayPath))
+            {
+                CameraManager::Get().SetActiveCamera(CameraManager::Get().GetPreviousActiveCamera()->GetMode());
+                if (CameraManager::Get().GetActiveCamera()->GetMode() == Camera::Mode::Free)
+                {
+                    UI::UIManager::Get().GetUIComponent(UI::Component::GameView)->SetHasFocus(true);
+                }
+               
             }
         }
     }

--- a/core/src/Components/CampathManager.cpp
+++ b/core/src/Components/CampathManager.cpp
@@ -64,6 +64,31 @@ namespace IWXMVM::Components
                 Playback::SetTickDelta(KeyframeManager::Get().GetKeyframes(property).front().tick -
                                        Mod::GetGameInterface()->GetDemoInfo().currentTick, true);
             }
+
+            if (Input::BindDown(Action::FirstPersonToggle))
+            {
+                if (activeCamera->GetMode() == Camera::Mode::FirstPerson)
+                {
+                    auto prevCamMode = CameraManager::Get().GetPreviousActiveCamera()->GetMode();
+                    if (prevCamMode == Camera::Mode::FirstPerson)
+                    {
+                        CameraManager::Get().SetActiveCamera(Camera::Mode::Free);
+                        UI::UIManager::Get().GetUIComponent(UI::Component::GameView)->SetHasFocus(true);
+                    }
+                    else
+                    {
+                        CameraManager::Get().SetActiveCamera(prevCamMode);
+                        if (CameraManager::Get().GetActiveCamera()->GetMode() == Camera::Mode::Free)
+                        {
+                            UI::UIManager::Get().GetUIComponent(UI::Component::GameView)->SetHasFocus(true);
+                        }
+                    }
+                }
+                else
+                {
+                    CameraManager::Get().SetActiveCamera(Camera::Mode::FirstPerson);
+                }
+            } 
         }
         else
         {
@@ -73,8 +98,7 @@ namespace IWXMVM::Components
                 if (CameraManager::Get().GetActiveCamera()->GetMode() == Camera::Mode::Free)
                 {
                     UI::UIManager::Get().GetUIComponent(UI::Component::GameView)->SetHasFocus(true);
-                }
-               
+                }  
             }
         }
     }

--- a/core/src/Components/Playback.cpp
+++ b/core/src/Components/Playback.cpp
@@ -28,7 +28,6 @@ namespace IWXMVM::Components::Playback
 
     void SetTickDelta(int32_t value, bool ignoreDeadzone)
     {
-        constexpr int32_t REWIND_DEADZONE = 250;
         if (value > 0)
             SkipForward(value);
         else if ((value < -REWIND_DEADZONE) || (value < 0 && ignoreDeadzone))

--- a/core/src/Components/Playback.hpp
+++ b/core/src/Components/Playback.hpp
@@ -9,7 +9,7 @@ namespace IWXMVM::Components
             0.25f, 0.333f, 0.5f, 0.75f, 1.0f, 1.25f, 1.5f,
             2.0f, 5.0f, 10.0f, 20.0f, 50.0f
         };
-
+        constexpr int32_t REWIND_DEADZONE = 250;
         void TogglePaused();
         bool IsPaused();
 

--- a/core/src/Configuration/InputConfiguration.cpp
+++ b/core/src/Configuration/InputConfiguration.cpp
@@ -31,6 +31,7 @@ namespace IWXMVM
             defaults[Action::PlaybackToggle]       = Bind{ImGuiKey_Space, "PlaybackToggle"};
             defaults[Action::TimeFrameMoveStart]   = Bind{ImGuiKey_B, "TimeFrameMoveStart"};
             defaults[Action::TimeFrameMoveEnd]     = Bind{ImGuiKey_N, "TimeFrameMoveEnd"};
+            defaults[Action::FirstPersonToggle]     = Bind{ImGuiKey_F2, "FirstPersonToggle"};
             return defaults;
         }())
     {

--- a/core/src/Configuration/InputConfiguration.hpp
+++ b/core/src/Configuration/InputConfiguration.hpp
@@ -27,6 +27,7 @@ namespace IWXMVM
         PlaybackToggle,
         TimeFrameMoveStart,
         TimeFrameMoveEnd,
+        FirstPersonToggle,
 
         Count,
     };

--- a/core/src/UI/Components/MenuBar.cpp
+++ b/core/src/UI/Components/MenuBar.cpp
@@ -42,12 +42,12 @@ namespace IWXMVM::UI
                     UIManager::Get().ToggleOverlay();
                 }
 
-                if (ImGui::MenuItem("Toggle ImGui Demo", "F2"))
+                if (ImGui::MenuItem("Toggle ImGui Demo", "F3"))
                 {
                     UIManager::Get().ToggleImGuiDemo();
                 }
 
-                if (ImGui::MenuItem("Toggle Debug Panel", "F3"))
+                if (ImGui::MenuItem("Toggle Debug Panel", "F4"))
                 {
                     UIManager::Get().ToggleDebugPanel();
                 }

--- a/core/src/UI/UIManager.cpp
+++ b/core/src/UI/UIManager.cpp
@@ -52,12 +52,12 @@ namespace IWXMVM::UI
                 ToggleOverlay();
             }
 
-            if (Input::KeyDown(ImGuiKey_F2))
+            if (Input::KeyDown(ImGuiKey_F3))
             {
                 ToggleImGuiDemo();
             }
 
-            if (Input::KeyDown(ImGuiKey_F3))
+            if (Input::KeyDown(ImGuiKey_F4))
             {
                 ToggleDebugPanel();
             }


### PR DESCRIPTION
PlaybackSkip keybinds will skip to Timeframe point if in range
Added DollyPlayPath functionality similar original iw3mvm
Added FirstPersonToggle keybind similar to original iw3mvm

Some old keybind habits from original iw3mvm stuck with me and I implemented them here. For example F2 to toggle firstperson and J to go in and out of dolly

also fixed bug when attempting to set camera mode to current mode