### PR TITLE
Disabled rewind error patches - more testing required

### DIFF
--- a/iw3/src/IW3Interface.hpp
+++ b/iw3/src/IW3Interface.hpp
@@ -526,6 +526,9 @@ namespace IWXMVM::IW3
         void ResetClientData(int serverTime)
         {
             auto cl = Structures::GetClientActive();
+            for (auto& snapshot : std::span{ cl->snapshots }) 
+                snapshot.valid = 0;
+
             cl->snap.serverTime = serverTime;
             cl->serverTime = 0;
             cl->oldServerTime = 0;

--- a/iw3/src/Patches.hpp
+++ b/iw3/src/Patches.hpp
@@ -23,11 +23,11 @@ namespace IWXMVM::IW3::Patches
 
         // For rewinding (not sure if all of these are actually necessary)
         NopPatch<5> Con_TimeJumped{GetGameAddresses().Con_TimeJumpedCall(), PatchApplySetting::Deferred};
-        NopPatch<2> CL_SetCGameTime{GetGameAddresses().CL_SetCGameTimeError(), PatchApplySetting::Immediately};
-        JumpPatch CL_CGameNeedsServerCommand{GetGameAddresses().CL_CGameNeedsServerCommandError(),
-                                             PatchApplySetting::Immediately};
-        JumpPatch CG_ProcessSnapshots{GetGameAddresses().CG_ProcessSnapshotsError(), PatchApplySetting::Immediately};
-        JumpPatch CG_ReadNextSnapshot{GetGameAddresses().CG_ReadNextSnapshotWarning(), PatchApplySetting::Immediately};
+        //NopPatch<2> CL_SetCGameTime{GetGameAddresses().CL_SetCGameTimeError(), PatchApplySetting::Immediately};
+        //JumpPatch CL_CGameNeedsServerCommand{GetGameAddresses().CL_CGameNeedsServerCommandError(),
+                                             //PatchApplySetting::Immediately};
+        //JumpPatch CG_ProcessSnapshots{GetGameAddresses().CG_ProcessSnapshotsError(), PatchApplySetting::Immediately};
+        //JumpPatch CG_ReadNextSnapshot{GetGameAddresses().CG_ReadNextSnapshotWarning(), PatchApplySetting::Immediately};
         NopPatch<5> CG_MapRestart{GetGameAddresses().CG_MapRestartSetThirdpersonCall(),
                                   PatchApplySetting::Immediately};  // Prevents cg_thirdperson from being reset
          

--- a/iw3/src/Signatures.hpp
+++ b/iw3/src/Signatures.hpp
@@ -63,11 +63,11 @@ namespace IWXMVM::IW3::Signatures
         Sig("83 3D ?? ?? ?? ?? ?? 0F 85 92 01 00 00", GAType::Code, -5,
             Lambda::FollowCodeFlow) > CL_FirstSnapshot;
         Sig("8B 15 ?? ?? ?? ?? 8B 42 0C 83 C4 04 80 38 00", GAType::Code, -5) > Con_TimeJumpedCall;
-        Sig("EB 0F 68 ?? ?? ?? ?? 6A 01 E8 ?? ?? ?? ?? 83 C4 08 83 3D", GAType::Code, -9) > CL_SetCGameTimeError;
-        Sig("6A 01 E8 ?? ?? ?? ?? 83 C4 08 8B 15 ?? ?? ?? ?? 8B FE", GAType::Code,
-            -7) > CL_CGameNeedsServerCommandError;
-        Sig("6A 01 E8 ?? ?? ?? ?? 83 C4 08 57 53", GAType::Code, -7) > CG_ProcessSnapshotsError;
-        Sig("6A 0E E8 ?? ?? ?? ?? 8B 0D ?? ?? ?? ?? A1", GAType::Code, -9) > CG_ReadNextSnapshotWarning;
+        //Sig("EB 0F 68 ?? ?? ?? ?? 6A 01 E8 ?? ?? ?? ?? 83 C4 08 83 3D", GAType::Code, -9) > CL_SetCGameTimeError;
+        //Sig("6A 01 E8 ?? ?? ?? ?? 83 C4 08 8B 15 ?? ?? ?? ?? 8B FE", GAType::Code,
+            //-7) > CL_CGameNeedsServerCommandError;
+        //Sig("6A 01 E8 ?? ?? ?? ?? 83 C4 08 57 53", GAType::Code, -7) > CG_ProcessSnapshotsError;
+        //Sig("6A 0E E8 ?? ?? ?? ?? 8B 0D ?? ?? ?? ?? A1", GAType::Code, -9) > CG_ReadNextSnapshotWarning;
         Sig("8B C7 69 C0 58 02 00 00", GAType::Code, -5) > CG_MapRestartSetThirdpersonCall;
 
         Sig("55 8B 6C 24 38 85 ED", GAType::Code, -5) > R_AddCmdDrawTextWithEffects;


### PR DESCRIPTION
I think this works correctly, but we'll need to test and then re-enable patches if needed.