### PR TITLE
two bug fixes with dollycam

### DIFF
--- a/core/src/Components/CampathManager.cpp
+++ b/core/src/Components/CampathManager.cpp
@@ -58,9 +58,9 @@ namespace IWXMVM::Components
 
             if (Input::BindDown(Action::DollyPlayPath))
             {
+                CameraManager::Get().SetActiveCamera(Camera::Mode::Dolly);
                 if (!KeyframeManager::Get().GetKeyframes(property).empty())
                 {
-                    CameraManager::Get().SetActiveCamera(Camera::Mode::Dolly);
                     Playback::SetTickDelta(KeyframeManager::Get().GetKeyframes(property).front().tick -
                                                Mod::GetGameInterface()->GetDemoInfo().currentTick, true);
                 }

--- a/core/src/Components/CampathManager.cpp
+++ b/core/src/Components/CampathManager.cpp
@@ -58,9 +58,12 @@ namespace IWXMVM::Components
 
             if (Input::BindDown(Action::DollyPlayPath))
             {
-                CameraManager::Get().SetActiveCamera(Camera::Mode::Dolly);
-                Playback::SetTickDelta(KeyframeManager::Get().GetKeyframes(property).front().tick -
-                                       Mod::GetGameInterface()->GetDemoInfo().currentTick, true);
+                if (!KeyframeManager::Get().GetKeyframes(property).empty())
+                {
+                    CameraManager::Get().SetActiveCamera(Camera::Mode::Dolly);
+                    Playback::SetTickDelta(KeyframeManager::Get().GetKeyframes(property).front().tick -
+                                               Mod::GetGameInterface()->GetDemoInfo().currentTick, true);
+                }
             }
 
             if (Input::BindDown(Action::FirstPersonToggle))

--- a/core/src/Components/DollyCamera.cpp
+++ b/core/src/Components/DollyCamera.cpp
@@ -12,13 +12,17 @@ namespace IWXMVM::Components
 
     void DollyCamera::Update()
     {
-        if (Rewinding::IsRewinding())
+        if (Rewinding::IsRewinding() )
             return;
+
+        auto& keyframeManager = KeyframeManager::Get();
+        const auto& property = keyframeManager.GetProperty(Types::KeyframeablePropertyType::CampathCamera);
+
+        if (keyframeManager.GetKeyframes(property).empty())
+            return;
+
         const auto currentTick = Mod::GetGameInterface()->GetDemoInfo().currentTick;
-        
-        const auto& keyframeManager = KeyframeManager::Get();
-        const auto interpolatedValue = keyframeManager.Interpolate(
-            keyframeManager.GetProperty(Types::KeyframeablePropertyType::CampathCamera), currentTick);
+        const auto interpolatedValue = keyframeManager.Interpolate(property, currentTick);
 
         this->GetPosition() = interpolatedValue.cameraData.position;
         this->GetRotation() = interpolatedValue.cameraData.rotation;


### PR DESCRIPTION
fixed a crash when trying to playdolly without keyframes
prevented setting dollycam camera data when no keyframes are present