### PR TITLE
Workaround for lost command strings when skipping forward.

### DIFF
--- a/core/src/Components/Rewinding.cpp
+++ b/core/src/Components/Rewinding.cpp
@@ -257,6 +257,9 @@ namespace IWXMVM::Components::Rewinding
         }
         else if (len > 12)
         {
+            // execute server commands here otherwise they may be lost when skipping forward a lot
+            Mod::GetGameInterface()->ExecuteNewServerCommands();
+
             // to exclude client archives (and CoD4X protocol header)
             StoreCurrentGamestate(len);
         }

--- a/core/src/GameInterface.hpp
+++ b/core/src/GameInterface.hpp
@@ -34,6 +34,7 @@ namespace IWXMVM
             return game;
         }
 
+        virtual void ExecuteNewServerCommands() = 0;
         virtual void InstallHooksAndPatches() = 0;
         virtual void SetupEventListeners() = 0;
 

--- a/iw3/src/IW3Interface.hpp
+++ b/iw3/src/IW3Interface.hpp
@@ -31,21 +31,38 @@ namespace IWXMVM::IW3
             const auto clc = Structures::GetClientConnection();
             const auto cgs = Structures::GetClientGlobalsStatic();
 
-            if (cgs->serverCommandSequence > 0 && cgs->serverCommandSequence < clc->serverCommandSequence)
-            {
-                const auto CG_ExecuteNewServerCommands = GetGameAddresses().CG_ExecuteNewServerCommands();
-                const auto serverCommandSequence = clc->serverCommandSequence;
+            const auto oldServerCommandSequence = cgs->serverCommandSequence;
+            const auto newServerCommandSequence = clc->serverCommandSequence;
 
+            // check if the command string backlog is equal to or greater than half the size of command string buffer (128 / 2 = 64)
+            if (oldServerCommandSequence > 0 && oldServerCommandSequence + std::ssize(clc->serverCommands) / 2 <= newServerCommandSequence)
+            {
+                for (auto i = oldServerCommandSequence + 1; i <= newServerCommandSequence; ++i)
+                {
+                    if (static constexpr auto dvar = 'd'; clc->serverCommands[i & 127][0] != dvar)
+                    {
+                        // erase all server commands that do not modify the gamestate strings
+                        clc->serverCommands[i & 127][0] = '\0';
+                    }
+                }
+
+                const auto CG_ExecuteNewServerCommands = GetGameAddresses().CG_ExecuteNewServerCommands();
                 __asm
                 {
                     pushad
-                    mov edi, serverCommandSequence
-                    push edi // serverCommandNum
-                    xor esi, esi
-                    push esi // localClientNum
+                    mov edi, newServerCommandSequence
+                    xor esi, esi // localClientNum
+                    push edi
+                    push esi
                     call CG_ExecuteNewServerCommands
                     add esp, 8
                     popad
+                }
+
+                for (auto i = oldServerCommandSequence + 1; i <= newServerCommandSequence; ++i)
+                {
+                    // erase server commands to prevent double processing; shouldn't be necessary but just to be sure
+                    clc->serverCommands[i & 127][0] = '\0';
                 }
             }
         }

--- a/iw3/src/IW3Interface.hpp
+++ b/iw3/src/IW3Interface.hpp
@@ -33,7 +33,7 @@ namespace IWXMVM::IW3
 
             if (cgs->serverCommandSequence > 0 && cgs->serverCommandSequence < clc->serverCommandSequence)
             {
-                const auto CG_ExecuteNewServerCommands = 0x44C630;
+                const auto CG_ExecuteNewServerCommands = GetGameAddresses().CG_ExecuteNewServerCommands();
                 const auto serverCommandSequence = clc->serverCommandSequence;
 
                 __asm

--- a/iw3/src/IW3Interface.hpp
+++ b/iw3/src/IW3Interface.hpp
@@ -41,7 +41,7 @@ namespace IWXMVM::IW3
                 {
                     if (static constexpr auto dvar = 'd'; clc->serverCommands[i & 127][0] != dvar)
                     {
-                        // erase all server commands that do not modify the gamestate strings
+                        // erase server commands that do not modify the gamestate strings
                         clc->serverCommands[i & 127][0] = '\0';
                     }
                 }

--- a/iw3/src/IW3Interface.hpp
+++ b/iw3/src/IW3Interface.hpp
@@ -26,6 +26,30 @@ namespace IWXMVM::IW3
         {
         }
 
+        void ExecuteNewServerCommands() final
+        {
+            const auto clc = Structures::GetClientConnection();
+            const auto cgs = Structures::GetClientGlobalsStatic();
+
+            if (cgs->serverCommandSequence > 0 && cgs->serverCommandSequence < clc->serverCommandSequence)
+            {
+                const auto CG_ExecuteNewServerCommands = 0x44C630;
+                const auto serverCommandSequence = clc->serverCommandSequence;
+
+                __asm
+                {
+                    pushad
+                    mov edi, serverCommandSequence
+                    push edi // serverCommandNum
+                    xor esi, esi
+                    push esi // localClientNum
+                    call CG_ExecuteNewServerCommands
+                    add esp, 8
+                    popad
+                }
+            }
+        }
+
         void InstallHooksAndPatches() final
         {
             Hooks::Install();

--- a/iw3/src/Signatures.hpp
+++ b/iw3/src/Signatures.hpp
@@ -78,6 +78,8 @@ namespace IWXMVM::IW3::Signatures
         Sig("83 3D ?? ?? ?? ?? 09 75 ?? ?? ?? ?? ?? ?? 8B CD", GAType::Code, 9, Lambda::FollowCodeFlow) > IN_Frame;
         Sig("83 C4 2C 5D 5B 59", GAType::Code, -5) > CG_DrawPlayerLowHealthOverlay;
         Sig("83 EC 14 53 8B 5D 08 56 57 8B F8 E8 ?? ?? ?? ?? 8B F0 85 F6 74 0E", GAType::Code, -6) > Dvar_SetStringByName;
+        Sig("E8 ?? ?? ?? ?? 8B BB ?? ?? ?? ?? 8B F5", GAType::Code, 13,
+            Lambda::FollowCodeFlow) > CG_ExecuteNewServerCommands;
 
         // cod4x
         using MType = Types::ModuleType;


### PR DESCRIPTION
Skipping forward a large amount makes the game read command strings, but it won't process them until it's finished skipping forward. The game has room for 128 command strings, so data may be lost in some cases. This can lead to problems if the command string was supposed to modify the gamestate strings (e.g. model name, sound alias etc).