### PR TITLE
Allow regular flinch player animations

### DIFF
--- a/iw3/src/Hooks/PlayerAnimation.cpp
+++ b/iw3/src/Hooks/PlayerAnimation.cpp
@@ -59,7 +59,7 @@ namespace IWXMVM::IW3::Hooks::PlayerAnimation
 
             auto IsBadIndex = [](auto index)
             {
-                static constexpr std::array animIndexRanges{std::array{253, 264}, std::array{273, 280}};
+                static constexpr std::array animIndexRanges{std::array{253, 260}, std::array{273, 280}};
 
                 return std::any_of(animIndexRanges.begin(), animIndexRanges.end(), [index](const auto range) {
                     return index >= range.front() && index <= range.back();


### PR DESCRIPTION
The current 'bad player animations' filter is too aggressive and is filtering out:
261: "pt_flinch_right"
262: "pt_flinch_left"
263: "pt_flinch_back"
264: "pt_flinch_forward"