### PR TITLE
A few changes for plutonium support

### DIFF
--- a/iw5/src/IW5Interface.hpp
+++ b/iw5/src/IW5Interface.hpp
@@ -215,6 +215,10 @@ namespace IWXMVM::IW5
              // TODO: Hack #2. I would, once again, strongly advise against exposing dvars directly to core...
             if (name.compare("timescale") == 0)
             {
+                // in plutonium clientdemoplayback timescale is not initialized until you watch a demo
+                if (Structures::GetClientDemoPlayback() == nullptr)
+                    return std::nullopt;
+
                 return Types::Dvar{name, (Types::Dvar::Value*)&Structures::GetClientDemoPlayback()->timeScale};
             }
 

--- a/iw5/src/Signatures.hpp
+++ b/iw5/src/Signatures.hpp
@@ -61,7 +61,7 @@ namespace IWXMVM::IW5::Signatures
             -6) > Scr_AllocString;
 
         Sig("C6 05 ?? ?? ?? ?? ?? 8B 08 8B 91 A4 00 00 00", GAType::Data, -4) > d3d9DevicePointer;
-        Sig("6A 02 FF 15 ?? ?? ?? ?? 8B 6C 24 48", GAType::Code, -5) > MainWndProc;
+        Sig("8B 6C 24 48 3B 2D 18 39 AA 05 0F 85", GAType::Code, -13) > MainWndProc;
 
 #undef Sig
 #undef Lambda


### PR DESCRIPTION
There is still a few bugs left that I only managed to solve through hacks which are not in this pull request.

The CL_Demo_SeekFile hook makes the game not want to load the demos at all. I don't really know what the issue is since plutonium demos overall don't want to get loaded on the steam version of mw3. However you can load steam demos on plutonium with no issues. If you are interested in getting demos to load temporarily, you can return the trampoline hook instead of the result which will let you play plutonium demos. Rewinding will be completely broken when watching demos.
https://github.com/reallyluckyy/IWXMVM/blob/b1a973feaeddb97b2886e0535a5aca6071516a5d/iw5/src/Hooks/Playback.cpp#L72

Another thing regarding the mainwndproc hook. Plutonium has done something to the mouse. The callback you get from SetWindowLongPtr does not return any mouse events which makes it basically impossible to interact with imgui. Maybe plutonium creates a WH_MOUSE_LL hook against cheaters? The mouse movement also feels really weird when in Free Cam mode with the mainwndproc hook, so it's not a solid solution but it at least allows for the user to place down camera path nodes.