### PR TITLE
Fix for plutonium not printing out log messages

### DIFF
--- a/core/src/Logger.hpp
+++ b/core/src/Logger.hpp
@@ -4,6 +4,7 @@
 #include "spdlog/spdlog.h"
 #include "spdlog/sinks/stdout_color_sinks.h"
 #include "spdlog/sinks/rotating_file_sink.h"
+#include "spdlog/sinks/ansicolor_sink.h"
 #pragma warning(pop)
 
 #define LOG_INFO(...) Logger::GetInternalLogger()->info(__VA_ARGS__)

--- a/core/src/WindowsConsole.cpp
+++ b/core/src/WindowsConsole.cpp
@@ -7,9 +7,21 @@ namespace IWXMVM
 
     void WindowsConsole::Open()
     {
-        if (AllocConsole())
+        // Try to allocate the windows console, if it already exists we set the std handle to ours.
+        if (GetConsoleWindow() == NULL)
         {
+            AllocConsole();
             freopen_s(&stream, "CONOUT$", "w", stdout);
+        }
+        else
+        {
+            HANDLE hConsole = NULL;
+
+            if (stream != NULL)
+                hConsole = (HANDLE)_get_osfhandle(_fileno(stream));
+
+            if (hConsole != NULL)
+                SetStdHandle(STD_OUTPUT_HANDLE, hConsole);
         }
     }
 


### PR DESCRIPTION
Since plutonium allocates the windows console before we do, we redirect the stdout handle to ours.
Also try forcing ANSI mode on for spdlog since plutonium's console is printing with ANSI colors which would make the console look messed up if we don't.