### PR TITLE
Sanitize invalid characters before copying demo file

### DIFF
--- a/iw3/src/IW3Interface.hpp
+++ b/iw3/src/IW3Interface.hpp
@@ -259,7 +259,17 @@ namespace IWXMVM::IW3
                 if (!std::filesystem::exists(tempDemoDirectory))
                     std::filesystem::create_directories(tempDemoDirectory);
 
-                const auto targetPath = tempDemoDirectory / demoPath.filename();
+                // an inline sanitation, should remove all invalid characters for IW3.
+                std::string sanitizedFileName;
+                for (char c : demoPath.filename().string())
+                {
+                    if (std::isalnum(static_cast<unsigned char>(c)) || c == '_' || c == '-' || c == '.')
+                    {
+                        sanitizedFileName += c;
+                    }
+                }
+
+                const auto targetPath = tempDemoDirectory / sanitizedFileName;
                 if (std::filesystem::exists(targetPath) && std::filesystem::is_regular_file(targetPath))
                     std::filesystem::remove(targetPath);
 


### PR DESCRIPTION
This will remove all "invalid" characters from the demo name before copying and playing them. IW3 does not seem to like the plus symbol, this should retain underscores, dashes and periods.